### PR TITLE
libaccelerate osx

### DIFF
--- a/.github/workflows/libaccelerate-osx-build.yml
+++ b/.github/workflows/libaccelerate-osx-build.yml
@@ -1,0 +1,16 @@
+name: "Build package: libaccelerate-osx"
+
+on:
+  pull_request:
+    branches:
+      - main
+      - petsc-*
+    paths:
+      - recipes/libaccelerate-osx/meta.yaml
+
+jobs:
+  build:
+    uses: ./.github/workflows/pkg-build.yml
+    with:
+      package-name: libaccelerate-osx
+    secrets: inherit

--- a/.github/workflows/libaccelerate-osx-deploy.yml
+++ b/.github/workflows/libaccelerate-osx-deploy.yml
@@ -1,0 +1,15 @@
+name: "Deploy package: libaccelerate-osx"
+
+on:
+  push:
+    branches:
+      - petsc-*
+    paths:
+      - recipes/libaccelerate-osx/meta.yaml
+
+jobs:
+  build:
+    uses: ./.github/workflows/pkg-deploy.yml
+    with:
+      package-name: libaccelerate-osx
+    secrets: inherit

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -33,15 +33,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: false
-          channels: andrsd,conda-forge,defaults
+          channels: andrsd,defaults
           channel-priority: strict
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
 
       - name: Install prerequisites
         run: |
-          mamba install \
+          conda install \
             conda-build \
             conda-verify \
             anaconda-client

--- a/.github/workflows/pkg-build.yml
+++ b/.github/workflows/pkg-build.yml
@@ -30,11 +30,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: false
-          channels: ${{ vars.CHANNEL_NAME }},conda-forge,main
+          channels: ${{ vars.CHANNEL_NAME }},main
           channel-priority: flexible
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
 
       - name: Install prerequisites
         run: |

--- a/recipes/libaccelerate-osx/meta.yaml
+++ b/recipes/libaccelerate-osx/meta.yaml
@@ -1,0 +1,18 @@
+{% set version = "1.0.0" %}
+{% set build = 0 %}
+
+package:
+  name: libaccelerate-osx
+  version: {{ version }}
+
+build:
+  number: "{{ build }}"
+  skip: true  # [linux or win]
+
+about:
+  summary: |
+    Meta-package for Apple-shipped Accelerate framework
+
+extra:
+  recipe-maintainers:
+    - andrsd


### PR DESCRIPTION
- removing mamba from the gha workflows
- libaccelerate-osx: version 1.0.0
